### PR TITLE
fix error running process_queue in a tz with a negative offset

### DIFF
--- a/eb_sqs/worker/service.py
+++ b/eb_sqs/worker/service.py
@@ -36,7 +36,7 @@ class WorkerService(object):
 
         queue_prefixes = [prefix.split(self._PREFIX_STR)[1] for prefix in prefixes]
         static_queues = queues
-        last_update_time = timezone.make_aware(datetime.min)
+        last_update_time = timezone.make_aware(datetime.min + timedelta(hours=24))
 
         logger.debug('[django-eb-sqs] Connected to SQS: {}'.format(', '.join(queue_names)))
 


### PR DESCRIPTION
In my django setting.py, I have `TIME_ZONE = 'US/Pacific'`. 

When I call `manage.py process_queue ...` I get the following error:

```
...
  File ".../venv/lib/python3.4/site-packages/eb_sqs/management/commands/process_queue.py", line 22, in handle
    WorkerService().process_queues(queue_names)
  File ".../venv/lib/python3.4/site-packages/eb_sqs/worker/service.py", line 39, in process_queues
    last_update_time = timezone.make_aware(datetime.min)
  File ".../venv/lib/python3.4/site-packages/django/utils/timezone.py", line 285, in make_aware
    return timezone.localize(value, is_dst=is_dst)
  File ".../venv/lib/python3.4/site-packages/pytz/tzinfo.py", line 309, in localize
    loc_dt = dt + delta
OverflowError: date value out of range
```

I've found by, instead of making `datetime.min` timezone aware, if we use just `datetime.min` + 24 hours as the fake last update time, it prevents the error from happening.